### PR TITLE
Make coverage target work on Linux and Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,21 +61,8 @@ a=rtpmap:99 h263-1998/90000
       (that we use).
 - For running the coverage target, gcov and lcov are additionally required.
 
-### Checkout CMock Submodule
-By default, the submodules in this repository are configured with `update=none`
-in [.gitmodules](./.gitmodules) to avoid increasing clone time and disk space
-usage of other repositories.
-
-To build unit tests, the submodule dependency of CMock is required. Use the
-following command to clone the submodule:
-
-```
-git submodule update --checkout --init --recursive test/CMock
-```
-
 ### Steps to build Unit Tests
-1. Go to the root directory of this repository. (Make sure that the CMock
-   submodule is cloned as described in [Checkout CMock Submodule](#checkout-cmock-submodule)).
+1. Go to the root directory of this repository.
 1. Run the following command to generate Makefiles:
 
     ```
@@ -96,17 +83,24 @@ git submodule update --checkout --init --recursive test/CMock
     ```
 
 ### Steps to generate code coverage report of Unit Test
-1. Run Unit Tests in [Steps to build Unit Tests](#steps-to-build-unit-tests).
-1. Generate coverage.info in build folder:
+1. Go to the root directory of this repository.
+1. Run the following command to generate Makefiles:
 
     ```
-    make coverage
+    cmake -S test/unit-test -B build/ -G "Unix Makefiles" \
+     -DCMAKE_BUILD_TYPE=Debug \
+     -DBUILD_CLONE_SUBMODULES=ON \
+     -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG'
+    ```
+1. Generate coverage report in `build/coverage` folder:
+
+    ```
+    cd build && make coverage
     ```
 
 ### Script to run Unit Test and generate code coverage report
 
 ```sh
-git submodule update --init --recursive --checkout test/CMock
 cmake -S test/unit-test -B build/ -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG'
 make -C build all
 cd build

--- a/README.md
+++ b/README.md
@@ -102,16 +102,6 @@ git submodule update --checkout --init --recursive test/CMock
     ```
     make coverage
     ```
-1. Get code coverage by lcov:
-
-    ```
-    lcov --rc lcov_branch_coverage=1 -r coverage.info -o coverage.info '*test*' '*CMakeCCompilerId*' '*mocks*'
-    ```
-1. Generage HTML report in folder `CodecovHTMLReport`:
-
-    ```
-    genhtml --rc lcov_branch_coverage=1 --ignore-errors source coverage.info --legend --output-directory=CodecovHTMLReport
-    ```
 
 ### Script to run Unit Test and generate code coverage report
 
@@ -122,6 +112,4 @@ make -C build all
 cd build
 ctest -E system --output-on-failure
 make coverage
-lcov --rc lcov_branch_coverage=1 -r coverage.info -o coverage.info '*test*' '*CMakeCCompilerId*' '*mocks*'
-genhtml --rc lcov_branch_coverage=1 --ignore-errors source coverage.info --legend --output-directory=CodecovHTMLReport
 ```

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -93,7 +93,8 @@ add_custom_target( coverage
     COMMAND ${CMAKE_COMMAND} -DCMOCK_DIR=${CMOCK_DIR}
     -P ${MODULE_ROOT_DIR}/test/unit-test/cmock/coverage.cmake
     DEPENDS cmock unity
-    sdp_serializer
+    sdp_serializer_utest
+    sdp_deserializer_utest
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )
 

--- a/test/unit-test/cmock/coverage.cmake
+++ b/test/unit-test/cmock/coverage.cmake
@@ -15,8 +15,8 @@ execute_process( COMMAND lcov --directory ${CMAKE_BINARY_DIR}
                          --initial
                          --capture
                          --rc lcov_branch_coverage=1
-                         --rc genhtml_branch_coverage=1
                          --output-file=${CMAKE_BINARY_DIR}/base_coverage.info
+                         --include "*source*"
         )
 file(GLOB files "${CMAKE_BINARY_DIR}/bin/tests/*")
 
@@ -46,10 +46,10 @@ execute_process(COMMAND ruby
 execute_process(
             COMMAND lcov --capture
                          --rc lcov_branch_coverage=1
-                         --rc genhtml_branch_coverage=1
                          --base-directory ${CMAKE_BINARY_DIR}
                          --directory ${CMAKE_BINARY_DIR}
                          --output-file ${CMAKE_BINARY_DIR}/second_coverage.info
+                         --include "*source*"
         )
 
 # combile baseline results (zeros) with the one after running the tests
@@ -61,6 +61,7 @@ execute_process(
                          --output-file ${CMAKE_BINARY_DIR}/coverage.info
                          --no-external
                          --rc lcov_branch_coverage=1
+                         --include "*source*"
         )
 execute_process(
             COMMAND genhtml --rc lcov_branch_coverage=1

--- a/test/unit-test/cmock/create_test.cmake
+++ b/test/unit-test/cmock/create_test.cmake
@@ -22,9 +22,6 @@ function(create_test test_name
             COMPILE_FLAG "-O0 -ggdb"
             RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/tests"
             INSTALL_RPATH_USE_LINK_PATH TRUE
-            LINK_FLAGS " \
-                -Wl,-rpath,${CMAKE_BINARY_DIR}/lib \
-                -Wl,-rpath,${CMAKE_CURRENT_BINARY_DIR}/lib"
         )
     target_include_directories(${test_name} PUBLIC
                                ${mocks_dir}
@@ -45,7 +42,7 @@ function(create_test test_name
         add_dependencies(${test_name} ${dependency})
         target_link_libraries(${test_name} ${dependency})
     endforeach()
-    target_link_libraries(${test_name} -lgcov unity)
+    target_link_libraries(${test_name} unity)
     target_link_directories(${test_name}  PUBLIC
                             ${CMAKE_CURRENT_BINARY_DIR}/lib
             )
@@ -129,10 +126,18 @@ function(create_mock_list mock_name
                                ${mocks_dir}
                                ${mock_include_list}
            )
-    set_target_properties(${mock_name} PROPERTIES
-                        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib
-                        POSITION_INDEPENDENT_CODE ON
-            )
+        if (APPLE)
+            set_target_properties(${mock_name} PROPERTIES
+                LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib
+                POSITION_INDEPENDENT_CODE ON
+                LINK_FLAGS  "-Wl,-undefined,dynamic_lookup"
+        )   
+       else()
+            set_target_properties(${mock_name} PROPERTIES
+                LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib
+                POSITION_INDEPENDENT_CODE ON
+        )  
+       endif()
     target_compile_definitions(${mock_name} PUBLIC
             ${mock_define_list}
         )
@@ -160,9 +165,8 @@ function(create_real_library target
             )
     if(NOT(mock_name STREQUAL ""))
         add_dependencies(${target} ${mock_name})
-        target_link_libraries(${target}
-                        -l${mock_name}
-                        -lgcov
+        target_link_libraries(
+                    ${target}
                 )
     endif()
 endfunction()

--- a/test/unit-test/cmock/create_test.cmake
+++ b/test/unit-test/cmock/create_test.cmake
@@ -126,18 +126,18 @@ function(create_mock_list mock_name
                                ${mocks_dir}
                                ${mock_include_list}
            )
-        if (APPLE)
-            set_target_properties(${mock_name} PROPERTIES
+    if (APPLE)
+        set_target_properties(${mock_name} PROPERTIES
                 LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib
                 POSITION_INDEPENDENT_CODE ON
                 LINK_FLAGS  "-Wl,-undefined,dynamic_lookup"
-        )   
-       else()
-            set_target_properties(${mock_name} PROPERTIES
+        )
+    else()
+        set_target_properties(${mock_name} PROPERTIES
                 LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib
                 POSITION_INDEPENDENT_CODE ON
-        )  
-       endif()
+        )
+    endif()
     target_compile_definitions(${mock_name} PUBLIC
             ${mock_define_list}
         )

--- a/test/unit-test/cmock_build.cmake
+++ b/test/unit-test/cmock_build.cmake
@@ -3,7 +3,7 @@ macro( clone_cmock )
         find_package( Git REQUIRED )
         message( "Cloning submodule CMock." )
         execute_process( COMMAND rm -rf ${CMOCK_DIR}
-                         COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive ${CMOCK_DIR}
+                         COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive --checkout ${CMOCK_DIR}
                         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
                         RESULT_VARIABLE CMOCK_CLONE_RESULT )
 


### PR DESCRIPTION
## Description of changes

`make coverage` was not working correctly on latest Ubuntu (24.04) and on Mac. This PR makes it work on both Ubuntu (24.04) and on Mac.

## Test Steps
```
git submodule update --init --recursive --checkout test/CMock
cmake -S test/unit-test -B build/ -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG'
make -C build all
cd build
ctest -E system --output-on-failure
make coverage
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
