### PR TITLE
Improved Code Coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ a=rtpmap:99 h263-1998/90000
 
     ```sh
     cmake -S test/unit-test -B build/ -G "Unix Makefiles" \
-     -DCMAKE_BUILD_TYPE=Debug \
+     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
      -DBUILD_CLONE_SUBMODULES=ON \
      -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG'
     ```
@@ -100,9 +100,6 @@ a=rtpmap:99 h263-1998/90000
 ### Script to run Unit Test and generate code coverage report
 
 ```sh
-cmake -S test/unit-test -B build/ -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG'
-make -C build all
-cd build
-ctest -E system --output-on-failure
-make coverage
+cmake -S test/unit-test -B build/ -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG' 
+cd build  && make coverage
 ```

--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ a=rtpmap:99 h263-1998/90000
 
     ```sh
     cmake -S test/unit-test -B build/ -G "Unix Makefiles" \
-     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
      -DBUILD_CLONE_SUBMODULES=ON \
      -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG'
     ```
@@ -100,6 +99,6 @@ a=rtpmap:99 h263-1998/90000
 ### Script to run Unit Test and generate code coverage report
 
 ```sh
-cmake -S test/unit-test -B build/ -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG' 
+cmake -S test/unit-test -B build/ -G "Unix Makefiles"  -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG' 
 cd build  && make coverage
 ```

--- a/source/sdp_serializer.c
+++ b/source/sdp_serializer.c
@@ -59,11 +59,12 @@ SdpResult_t SdpSerializer_AddBuffer( SdpSerializerContext_t * pCtx,
                                    "%c=%.*s\r\n",
                                    type,
                                    ( int ) valueLength, pValue );
-
-        if( snprintfRetVal < 0 ) //LCOV_EXCL_BR_LINE
+        //LCOV_EXCL_START
+        if( snprintfRetVal < 0 )
         {
-            result = SDP_RESULT_SNPRINTF_ERROR; // LCOV_EXCL_LINE
+            result = SDP_RESULT_SNPRINTF_ERROR; 
         }
+        //LCOV_EXCL_STOP                                      
         else if( ( pWriteBuffer != NULL ) && ( ( size_t ) snprintfRetVal >= remainingLength ) )
         {
             result = SDP_RESULT_OUT_OF_MEMORY;
@@ -108,11 +109,12 @@ SdpResult_t SdpSerializer_AddU32( SdpSerializerContext_t * pCtx,
                                    "=%" SDP_PRINT_FMT_UINT32 "\r\n",
                                    type,
                                    value );
-
-        if( snprintfRetVal < 0 ) //LCOV_EXCL_BR_LINE
+        //LCOV_EXCL_START
+        if( snprintfRetVal < 0 )
         {
-            result = SDP_RESULT_SNPRINTF_ERROR; // LCOV_EXCL_LINE
+            result = SDP_RESULT_SNPRINTF_ERROR; 
         }
+        //LCOV_EXCL_STOP   
         else if( ( pWriteBuffer != NULL ) && ( ( size_t ) snprintfRetVal >= remainingLength ) )
         {
             result = SDP_RESULT_OUT_OF_MEMORY;
@@ -157,11 +159,12 @@ SdpResult_t SdpSerializer_AddU64( SdpSerializerContext_t * pCtx,
                                    "=%" SDP_PRINT_FMT_UINT64 "\r\n",
                                    type,
                                    value );
-
-        if( snprintfRetVal < 0 ) //LCOV_EXCL_BR_LINE
+        //LCOV_EXCL_START
+        if( snprintfRetVal < 0 )
         {
-            result = SDP_RESULT_SNPRINTF_ERROR; // LCOV_EXCL_LINE
+            result = SDP_RESULT_SNPRINTF_ERROR; 
         }
+        //LCOV_EXCL_STOP   
         else if( ( pWriteBuffer != NULL ) && ( ( size_t ) snprintfRetVal >= remainingLength ) )
         {
             result = SDP_RESULT_OUT_OF_MEMORY;
@@ -222,10 +225,12 @@ SdpResult_t SdpSerializer_AddOriginator( SdpSerializerContext_t * pCtx,
                                    3, pOriginator->connectionInfo.addressType == SDP_ADDRESS_IPV4 ? "IP4" : "IP6",
                                    ( int ) pOriginator->connectionInfo.addressLength, pOriginator->connectionInfo.pAddress );
 
-        if( snprintfRetVal < 0 ) //LCOV_EXCL_BR_LINE
+        //LCOV_EXCL_START
+        if( snprintfRetVal < 0 )
         {
-            result = SDP_RESULT_SNPRINTF_ERROR; // LCOV_EXCL_LINE
+            result = SDP_RESULT_SNPRINTF_ERROR; 
         }
+        //LCOV_EXCL_STOP   
         else if( ( pWriteBuffer != NULL ) && ( ( size_t ) snprintfRetVal >= remainingLength ) )
         {
             result = SDP_RESULT_OUT_OF_MEMORY;
@@ -277,10 +282,12 @@ SdpResult_t SdpSerializer_AddConnectionInfo( SdpSerializerContext_t * pCtx,
                                    3, pConnInfo->addressType == SDP_ADDRESS_IPV4 ? "IP4" : "IP6",
                                    ( int ) pConnInfo->addressLength, pConnInfo->pAddress );
 
-        if( snprintfRetVal < 0 ) //LCOV_EXCL_BR_LINE
+        //LCOV_EXCL_START
+        if( snprintfRetVal < 0 )
         {
-            result = SDP_RESULT_SNPRINTF_ERROR; // LCOV_EXCL_LINE
+            result = SDP_RESULT_SNPRINTF_ERROR; 
         }
+        //LCOV_EXCL_STOP   
         else if( ( pWriteBuffer != NULL ) && ( ( size_t ) snprintfRetVal >= remainingLength ) )
         {
             result = SDP_RESULT_OUT_OF_MEMORY;
@@ -329,10 +336,12 @@ SdpResult_t SdpSerializer_AddBandwidthInfo( SdpSerializerContext_t * pCtx,
                                    ( int ) pBandwidthInfo->bwTypeLength, pBandwidthInfo->pBwType,
                                    pBandwidthInfo->sdpBandwidthValue );
 
-        if( snprintfRetVal < 0 ) //LCOV_EXCL_BR_LINE
+        //LCOV_EXCL_START
+        if( snprintfRetVal < 0 )
         {
-            result = SDP_RESULT_SNPRINTF_ERROR; // LCOV_EXCL_LINE
+            result = SDP_RESULT_SNPRINTF_ERROR; 
         }
+        //LCOV_EXCL_STOP   
         else if( ( pWriteBuffer != NULL ) && ( ( size_t ) snprintfRetVal >= remainingLength ) )
         {
             result = SDP_RESULT_OUT_OF_MEMORY;
@@ -381,10 +390,12 @@ SdpResult_t SdpSerializer_AddTimeActive( SdpSerializerContext_t * pCtx,
                                    pTimeDescription->startTime,
                                    pTimeDescription->stopTime );
 
-        if( snprintfRetVal < 0 ) //LCOV_EXCL_BR_LINE
+        //LCOV_EXCL_START
+        if( snprintfRetVal < 0 )
         {
-            result = SDP_RESULT_SNPRINTF_ERROR; // LCOV_EXCL_LINE
+            result = SDP_RESULT_SNPRINTF_ERROR; 
         }
+        //LCOV_EXCL_STOP   
         else if( ( pWriteBuffer != NULL ) && ( ( size_t ) snprintfRetVal >= remainingLength ) )
         {
             result = SDP_RESULT_OUT_OF_MEMORY;
@@ -443,10 +454,12 @@ SdpResult_t SdpSerializer_AddAttribute( SdpSerializerContext_t * pCtx,
                                        ( int ) pAttribute->attributeNameLength, pAttribute->pAttributeName );
         }
 
-        if( snprintfRetVal < 0 ) //LCOV_EXCL_BR_LINE
+        //LCOV_EXCL_START
+        if( snprintfRetVal < 0 )
         {
-            result = SDP_RESULT_SNPRINTF_ERROR; // LCOV_EXCL_LINE
+            result = SDP_RESULT_SNPRINTF_ERROR; 
         }
+        //LCOV_EXCL_STOP   
         else if( ( pWriteBuffer != NULL ) && ( ( size_t ) snprintfRetVal >= remainingLength ) )
         {
             result = SDP_RESULT_OUT_OF_MEMORY;
@@ -521,10 +534,12 @@ SdpResult_t SdpSerializer_AddMedia( SdpSerializerContext_t * pCtx,
                                        ( int ) pMedia->fmtLength, pMedia->pFmt );
         }
 
-        if( snprintfRetVal < 0 ) //LCOV_EXCL_BR_LINE
+        //LCOV_EXCL_START
+        if( snprintfRetVal < 0 )
         {
-            result = SDP_RESULT_SNPRINTF_ERROR; // LCOV_EXCL_LINE
+            result = SDP_RESULT_SNPRINTF_ERROR; 
         }
+        //LCOV_EXCL_STOP   
         else if( ( pWriteBuffer != NULL ) && ( ( size_t ) snprintfRetVal >= remainingLength ) )
         {
             result = SDP_RESULT_OUT_OF_MEMORY;

--- a/source/sdp_serializer.c
+++ b/source/sdp_serializer.c
@@ -59,12 +59,12 @@ SdpResult_t SdpSerializer_AddBuffer( SdpSerializerContext_t * pCtx,
                                    "%c=%.*s\r\n",
                                    type,
                                    ( int ) valueLength, pValue );
-        //LCOV_EXCL_START
+        /* LCOV_EXCL_START */
         if( snprintfRetVal < 0 )
         {
             result = SDP_RESULT_SNPRINTF_ERROR; 
         }
-        //LCOV_EXCL_STOP                                      
+        /* LCOV_EXCL_STOP  */                                    
         else if( ( pWriteBuffer != NULL ) && ( ( size_t ) snprintfRetVal >= remainingLength ) )
         {
             result = SDP_RESULT_OUT_OF_MEMORY;
@@ -109,12 +109,12 @@ SdpResult_t SdpSerializer_AddU32( SdpSerializerContext_t * pCtx,
                                    "=%" SDP_PRINT_FMT_UINT32 "\r\n",
                                    type,
                                    value );
-        //LCOV_EXCL_START
+        /* LCOV_EXCL_START */
         if( snprintfRetVal < 0 )
         {
             result = SDP_RESULT_SNPRINTF_ERROR; 
         }
-        //LCOV_EXCL_STOP   
+        /* LCOV_EXCL_STOP  */  
         else if( ( pWriteBuffer != NULL ) && ( ( size_t ) snprintfRetVal >= remainingLength ) )
         {
             result = SDP_RESULT_OUT_OF_MEMORY;
@@ -159,12 +159,12 @@ SdpResult_t SdpSerializer_AddU64( SdpSerializerContext_t * pCtx,
                                    "=%" SDP_PRINT_FMT_UINT64 "\r\n",
                                    type,
                                    value );
-        //LCOV_EXCL_START
+        /* LCOV_EXCL_START */
         if( snprintfRetVal < 0 )
         {
             result = SDP_RESULT_SNPRINTF_ERROR; 
         }
-        //LCOV_EXCL_STOP   
+        /* LCOV_EXCL_STOP  */   
         else if( ( pWriteBuffer != NULL ) && ( ( size_t ) snprintfRetVal >= remainingLength ) )
         {
             result = SDP_RESULT_OUT_OF_MEMORY;
@@ -225,12 +225,12 @@ SdpResult_t SdpSerializer_AddOriginator( SdpSerializerContext_t * pCtx,
                                    3, pOriginator->connectionInfo.addressType == SDP_ADDRESS_IPV4 ? "IP4" : "IP6",
                                    ( int ) pOriginator->connectionInfo.addressLength, pOriginator->connectionInfo.pAddress );
 
-        //LCOV_EXCL_START
+        /* LCOV_EXCL_START */
         if( snprintfRetVal < 0 )
         {
             result = SDP_RESULT_SNPRINTF_ERROR; 
         }
-        //LCOV_EXCL_STOP   
+        /* LCOV_EXCL_STOP  */   
         else if( ( pWriteBuffer != NULL ) && ( ( size_t ) snprintfRetVal >= remainingLength ) )
         {
             result = SDP_RESULT_OUT_OF_MEMORY;
@@ -282,12 +282,12 @@ SdpResult_t SdpSerializer_AddConnectionInfo( SdpSerializerContext_t * pCtx,
                                    3, pConnInfo->addressType == SDP_ADDRESS_IPV4 ? "IP4" : "IP6",
                                    ( int ) pConnInfo->addressLength, pConnInfo->pAddress );
 
-        //LCOV_EXCL_START
+        /* LCOV_EXCL_START */
         if( snprintfRetVal < 0 )
         {
             result = SDP_RESULT_SNPRINTF_ERROR; 
         }
-        //LCOV_EXCL_STOP   
+        /* LCOV_EXCL_STOP  */   
         else if( ( pWriteBuffer != NULL ) && ( ( size_t ) snprintfRetVal >= remainingLength ) )
         {
             result = SDP_RESULT_OUT_OF_MEMORY;
@@ -336,12 +336,12 @@ SdpResult_t SdpSerializer_AddBandwidthInfo( SdpSerializerContext_t * pCtx,
                                    ( int ) pBandwidthInfo->bwTypeLength, pBandwidthInfo->pBwType,
                                    pBandwidthInfo->sdpBandwidthValue );
 
-        //LCOV_EXCL_START
+        /* LCOV_EXCL_START */
         if( snprintfRetVal < 0 )
         {
             result = SDP_RESULT_SNPRINTF_ERROR; 
         }
-        //LCOV_EXCL_STOP   
+        /* LCOV_EXCL_STOP  */   
         else if( ( pWriteBuffer != NULL ) && ( ( size_t ) snprintfRetVal >= remainingLength ) )
         {
             result = SDP_RESULT_OUT_OF_MEMORY;
@@ -390,12 +390,12 @@ SdpResult_t SdpSerializer_AddTimeActive( SdpSerializerContext_t * pCtx,
                                    pTimeDescription->startTime,
                                    pTimeDescription->stopTime );
 
-        //LCOV_EXCL_START
+        /* LCOV_EXCL_START */
         if( snprintfRetVal < 0 )
         {
             result = SDP_RESULT_SNPRINTF_ERROR; 
         }
-        //LCOV_EXCL_STOP   
+        /* LCOV_EXCL_STOP  */ 
         else if( ( pWriteBuffer != NULL ) && ( ( size_t ) snprintfRetVal >= remainingLength ) )
         {
             result = SDP_RESULT_OUT_OF_MEMORY;
@@ -454,12 +454,12 @@ SdpResult_t SdpSerializer_AddAttribute( SdpSerializerContext_t * pCtx,
                                        ( int ) pAttribute->attributeNameLength, pAttribute->pAttributeName );
         }
 
-        //LCOV_EXCL_START
+        /* LCOV_EXCL_START */
         if( snprintfRetVal < 0 )
         {
             result = SDP_RESULT_SNPRINTF_ERROR; 
         }
-        //LCOV_EXCL_STOP   
+        /* LCOV_EXCL_STOP  */ 
         else if( ( pWriteBuffer != NULL ) && ( ( size_t ) snprintfRetVal >= remainingLength ) )
         {
             result = SDP_RESULT_OUT_OF_MEMORY;
@@ -534,12 +534,12 @@ SdpResult_t SdpSerializer_AddMedia( SdpSerializerContext_t * pCtx,
                                        ( int ) pMedia->fmtLength, pMedia->pFmt );
         }
 
-        //LCOV_EXCL_START
+        /* LCOV_EXCL_START */
         if( snprintfRetVal < 0 )
         {
             result = SDP_RESULT_SNPRINTF_ERROR; 
         }
-        //LCOV_EXCL_STOP   
+        /* LCOV_EXCL_STOP  */  
         else if( ( pWriteBuffer != NULL ) && ( ( size_t ) snprintfRetVal >= remainingLength ) )
         {
             result = SDP_RESULT_OUT_OF_MEMORY;

--- a/source/sdp_serializer.c
+++ b/source/sdp_serializer.c
@@ -62,9 +62,9 @@ SdpResult_t SdpSerializer_AddBuffer( SdpSerializerContext_t * pCtx,
         /* LCOV_EXCL_START */
         if( snprintfRetVal < 0 )
         {
-            result = SDP_RESULT_SNPRINTF_ERROR; 
+            result = SDP_RESULT_SNPRINTF_ERROR;
         }
-        /* LCOV_EXCL_STOP  */                                    
+        /* LCOV_EXCL_STOP  */
         else if( ( pWriteBuffer != NULL ) && ( ( size_t ) snprintfRetVal >= remainingLength ) )
         {
             result = SDP_RESULT_OUT_OF_MEMORY;
@@ -112,9 +112,9 @@ SdpResult_t SdpSerializer_AddU32( SdpSerializerContext_t * pCtx,
         /* LCOV_EXCL_START */
         if( snprintfRetVal < 0 )
         {
-            result = SDP_RESULT_SNPRINTF_ERROR; 
+            result = SDP_RESULT_SNPRINTF_ERROR;
         }
-        /* LCOV_EXCL_STOP  */  
+        /* LCOV_EXCL_STOP  */
         else if( ( pWriteBuffer != NULL ) && ( ( size_t ) snprintfRetVal >= remainingLength ) )
         {
             result = SDP_RESULT_OUT_OF_MEMORY;
@@ -162,9 +162,9 @@ SdpResult_t SdpSerializer_AddU64( SdpSerializerContext_t * pCtx,
         /* LCOV_EXCL_START */
         if( snprintfRetVal < 0 )
         {
-            result = SDP_RESULT_SNPRINTF_ERROR; 
+            result = SDP_RESULT_SNPRINTF_ERROR;
         }
-        /* LCOV_EXCL_STOP  */   
+        /* LCOV_EXCL_STOP  */
         else if( ( pWriteBuffer != NULL ) && ( ( size_t ) snprintfRetVal >= remainingLength ) )
         {
             result = SDP_RESULT_OUT_OF_MEMORY;
@@ -228,9 +228,9 @@ SdpResult_t SdpSerializer_AddOriginator( SdpSerializerContext_t * pCtx,
         /* LCOV_EXCL_START */
         if( snprintfRetVal < 0 )
         {
-            result = SDP_RESULT_SNPRINTF_ERROR; 
+            result = SDP_RESULT_SNPRINTF_ERROR;
         }
-        /* LCOV_EXCL_STOP  */   
+        /* LCOV_EXCL_STOP  */
         else if( ( pWriteBuffer != NULL ) && ( ( size_t ) snprintfRetVal >= remainingLength ) )
         {
             result = SDP_RESULT_OUT_OF_MEMORY;
@@ -285,9 +285,9 @@ SdpResult_t SdpSerializer_AddConnectionInfo( SdpSerializerContext_t * pCtx,
         /* LCOV_EXCL_START */
         if( snprintfRetVal < 0 )
         {
-            result = SDP_RESULT_SNPRINTF_ERROR; 
+            result = SDP_RESULT_SNPRINTF_ERROR;
         }
-        /* LCOV_EXCL_STOP  */   
+        /* LCOV_EXCL_STOP  */
         else if( ( pWriteBuffer != NULL ) && ( ( size_t ) snprintfRetVal >= remainingLength ) )
         {
             result = SDP_RESULT_OUT_OF_MEMORY;
@@ -339,9 +339,9 @@ SdpResult_t SdpSerializer_AddBandwidthInfo( SdpSerializerContext_t * pCtx,
         /* LCOV_EXCL_START */
         if( snprintfRetVal < 0 )
         {
-            result = SDP_RESULT_SNPRINTF_ERROR; 
+            result = SDP_RESULT_SNPRINTF_ERROR;
         }
-        /* LCOV_EXCL_STOP  */   
+        /* LCOV_EXCL_STOP  */
         else if( ( pWriteBuffer != NULL ) && ( ( size_t ) snprintfRetVal >= remainingLength ) )
         {
             result = SDP_RESULT_OUT_OF_MEMORY;
@@ -393,9 +393,9 @@ SdpResult_t SdpSerializer_AddTimeActive( SdpSerializerContext_t * pCtx,
         /* LCOV_EXCL_START */
         if( snprintfRetVal < 0 )
         {
-            result = SDP_RESULT_SNPRINTF_ERROR; 
+            result = SDP_RESULT_SNPRINTF_ERROR;
         }
-        /* LCOV_EXCL_STOP  */ 
+        /* LCOV_EXCL_STOP  */
         else if( ( pWriteBuffer != NULL ) && ( ( size_t ) snprintfRetVal >= remainingLength ) )
         {
             result = SDP_RESULT_OUT_OF_MEMORY;
@@ -457,9 +457,9 @@ SdpResult_t SdpSerializer_AddAttribute( SdpSerializerContext_t * pCtx,
         /* LCOV_EXCL_START */
         if( snprintfRetVal < 0 )
         {
-            result = SDP_RESULT_SNPRINTF_ERROR; 
+            result = SDP_RESULT_SNPRINTF_ERROR;
         }
-        /* LCOV_EXCL_STOP  */ 
+        /* LCOV_EXCL_STOP  */
         else if( ( pWriteBuffer != NULL ) && ( ( size_t ) snprintfRetVal >= remainingLength ) )
         {
             result = SDP_RESULT_OUT_OF_MEMORY;
@@ -537,9 +537,9 @@ SdpResult_t SdpSerializer_AddMedia( SdpSerializerContext_t * pCtx,
         /* LCOV_EXCL_START */
         if( snprintfRetVal < 0 )
         {
-            result = SDP_RESULT_SNPRINTF_ERROR; 
+            result = SDP_RESULT_SNPRINTF_ERROR;
         }
-        /* LCOV_EXCL_STOP  */  
+        /* LCOV_EXCL_STOP  */
         else if( ( pWriteBuffer != NULL ) && ( ( size_t ) snprintfRetVal >= remainingLength ) )
         {
             result = SDP_RESULT_OUT_OF_MEMORY;

--- a/test/unit-test/sdp_deserializer/sdp_deserializer_utest.c
+++ b/test/unit-test/sdp_deserializer/sdp_deserializer_utest.c
@@ -367,6 +367,27 @@ void test_SdpDeserializer_GetNext_Pass_r( void )
 /*-----------------------------------------------------------*/
 
 /**
+ * @brief Validate SDP Deserializer Parse Originator fail functionality for Bad Parameters.
+ */
+void test_SdpDeserializer_ParseOriginator_BadParams( void )
+{
+    SdpResult_t result;
+    char originatorBuffer[] ="larry ";
+    size_t inputLength = strlen( originatorBuffer );
+    SdpOriginator_t originator;
+
+    result = SdpDeserializer_ParseOriginator( NULL, 0, &( originator ) );
+
+    TEST_ASSERT_EQUAL( SDP_RESULT_BAD_PARAM, result );
+
+    result = SdpDeserializer_ParseOriginator( originatorBuffer, inputLength, NULL );
+
+    TEST_ASSERT_EQUAL( SDP_RESULT_BAD_PARAM, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
  * @brief The message is malformed message without SessionId.
  */
 void test_SdpDeserializer_ParseOriginator_NoSessionId( void )
@@ -490,6 +511,27 @@ void test_SdpDeserializer_ParseOriginator_Pass( void )
     TEST_ASSERT_EQUAL( SDP_ADDRESS_IPV4, originator.connectionInfo.addressType );
     TEST_ASSERT_EQUAL( strlen( addv4 ), originator.connectionInfo.addressLength );
     TEST_ASSERT_EQUAL_STRING_LEN( addv4,originator.connectionInfo.pAddress, originator.connectionInfo.addressLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate SDP Deserializer Parse Connection Info fail functionality for Bad Parameters.
+ */
+void test_SdpDeserializer_ParseConnectionInfo_BadParams( void )
+{
+    SdpResult_t result;
+    char originatorBuffer[] ="INe IP4 128.112.136.10";
+    size_t inputLength = strlen( originatorBuffer );
+    SdpConnectionInfo_t ConnInfo;
+
+    result = SdpDeserializer_ParseConnectionInfo( NULL, 0, &( ConnInfo ) );
+
+    TEST_ASSERT_EQUAL( SDP_RESULT_BAD_PARAM, result );
+
+    result = SdpDeserializer_ParseConnectionInfo( originatorBuffer, inputLength, NULL );
+
+    TEST_ASSERT_EQUAL( SDP_RESULT_BAD_PARAM, result );
 }
 
 /*-----------------------------------------------------------*/
@@ -642,6 +684,27 @@ void test_SdpDeserializer_ParseConnectionInfo_PassIPv6( void )
 /*-----------------------------------------------------------*/
 
 /**
+ * @brief Validate SDP Deserializer Parse Bandwidth Info fail functionality for Bad Parameters.
+ */
+void test_SdpDeserializer_ParseBandwidthInfo_BadParams( void )
+{
+    SdpResult_t result;
+    char originatorBuffer[] ="X-YZ:";
+    size_t inputLength = strlen( originatorBuffer );
+    SdpBandwidthInfo_t bandwidth;
+
+    result = SdpDeserializer_ParseBandwidthInfo( NULL, 0, &( bandwidth ) );
+
+    TEST_ASSERT_EQUAL( SDP_RESULT_BAD_PARAM, result );
+
+    result = SdpDeserializer_ParseBandwidthInfo( originatorBuffer, inputLength, NULL );
+
+    TEST_ASSERT_EQUAL( SDP_RESULT_BAD_PARAM, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
  * @brief The message is malformed with no sdpBandwidthValue.
  */
 void test_SdpDeserializer_ParseBandwidthInfo_NoBandwidthValue( void )
@@ -690,6 +753,27 @@ void test_SdpDeserializer_ParseBandwidthInfo_Pass( void )
     TEST_ASSERT_EQUAL( strlen( BwType ), bandwidth.bwTypeLength );
     TEST_ASSERT_EQUAL( 128, bandwidth.sdpBandwidthValue );
     TEST_ASSERT_EQUAL_STRING_LEN( BwType, bandwidth.pBwType, bandwidth.bwTypeLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate SDP Deserializer Parse Time Active fail functionality for Bad Parameters.
+ */
+void test_SdpDeserializer_ParseTimeActive_BadParams( void )
+{
+    SdpResult_t result;
+    char originatorBuffer[] ="0 0";
+    size_t inputLength = strlen( originatorBuffer );
+    SdpTimeDescription_t timeDescription;
+
+    result = SdpDeserializer_ParseTimeActive( NULL, 0, &( timeDescription ) );
+
+    TEST_ASSERT_EQUAL( SDP_RESULT_BAD_PARAM, result );
+
+    result = SdpDeserializer_ParseTimeActive( originatorBuffer, inputLength, NULL );
+
+    TEST_ASSERT_EQUAL( SDP_RESULT_BAD_PARAM, result );
 }
 
 /*-----------------------------------------------------------*/
@@ -764,6 +848,29 @@ void test_SdpDeserializer_ParseTimeActive_Pass( void )
 /*-----------------------------------------------------------*/
 
 /**
+ * @brief Validate SDP Deserializer Parse Attribute fail functionality for Bad Parameters.
+ */
+void test_SdpDeserializer_ParseAttribute_BadParams( void )
+{
+    SdpResult_t result;
+    char attributeString[] = "rtpmap:126 telephone-event/8000";
+    size_t attributeStringLength = strlen( attributeString );
+    SdpAttribute_t attribute;
+
+    memset( &( attribute ), 0, sizeof( SdpAttribute_t ) );
+
+    result = SdpDeserializer_ParseAttribute( NULL, 0, &( attribute ) );
+
+    TEST_ASSERT_EQUAL( SDP_RESULT_BAD_PARAM, result );
+
+    result = SdpDeserializer_ParseAttribute( attributeString, attributeStringLength, NULL );
+
+    TEST_ASSERT_EQUAL( SDP_RESULT_BAD_PARAM, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
  * @brief Inputs are valid.
  */
 void test_SdpDeserializer_ParseAttribute_Pass( void )
@@ -811,6 +918,29 @@ void test_SdpDeserializer_ParseAttribute_PassNoAttributeValue( void )
     TEST_ASSERT_EQUAL_size_t( 0, attribute.attributeValueLength );
     TEST_ASSERT_EQUAL_STRING_LEN( expectAttributeName, attribute.pAttributeName, attribute.attributeNameLength );
     TEST_ASSERT_EQUAL_STRING_LEN( NULL, attribute.pAttributeValue, attribute.attributeValueLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate SDP Deserializer Parse Media fail functionality for Bad Parameters.
+ */
+void test_SdpDeserializer_ParseMedia_BadParams( void )
+{
+    SdpResult_t result;
+    char mediaString[] = "video 9/2 UDP/TLS/RTP/SAVPF 96 97 102 103 104 105 106 107 108 109 127 125 39 40 45 46 98 99 100 101 112 113 116 117 118";
+    size_t mediaStringLength = strlen( mediaString );
+    SdpMedia_t media;
+
+    memset( &( media ), 0, sizeof( SdpMedia_t ) );
+
+    result = SdpDeserializer_ParseMedia( NULL, 0, &( media ) );
+
+    TEST_ASSERT_EQUAL( SDP_RESULT_BAD_PARAM, result );
+
+    result = SdpDeserializer_ParseMedia( mediaString, mediaStringLength, NULL );
+
+    TEST_ASSERT_EQUAL( SDP_RESULT_BAD_PARAM, result );
 }
 
 /*-----------------------------------------------------------*/

--- a/test/unit-test/sdp_deserializer/sdp_deserializer_utest.c
+++ b/test/unit-test/sdp_deserializer/sdp_deserializer_utest.c
@@ -523,9 +523,9 @@ void test_SdpDeserializer_ParseConnectionInfo_BadParams( void )
     SdpResult_t result;
     char originatorBuffer[] ="INe IP4 128.112.136.10";
     size_t inputLength = strlen( originatorBuffer );
-    SdpConnectionInfo_t ConnInfo;
+    SdpConnectionInfo_t connInfo;
 
-    result = SdpDeserializer_ParseConnectionInfo( NULL, 0, &( ConnInfo ) );
+    result = SdpDeserializer_ParseConnectionInfo( NULL, 0, &( connInfo ) );
 
     TEST_ASSERT_EQUAL( SDP_RESULT_BAD_PARAM, result );
 


### PR DESCRIPTION
### Description of changes:

This PR is for adding additional unit tests to improve coverage, by thoroughly testing various SDP API's . Majority of the UT in this PR are for testing conditions of **Bad Parameters**.

README.md is edited for building the cmake for Coverage report specifically and `LCOV_EXCL_BR_LINE` was replaced from the source to `LCOV_EXCL_START        LCOV_EXCL_STOP`

The following test cases have been added:
1. `test_SdpDeserializer_ParseOriginator_BadParams`
2. `test_SdpDeserializer_ParseConnectionInfo_BadParams`
3. `test_SdpDeserializer_ParseBandwidthInfo_BadParams`
4. `test_SdpDeserializer_ParseTimeActive_BadParams`
5. `test_SdpDeserializer_ParseAttribute_BadParams`
6. `test_SdpDeserializer_ParseMedia_BadParams`

### Test Steps

```
cmake -S test/unit-test -B build/ -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG'

cd build  && make coverage
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
