### PR TITLE
Added github actions for code coverage ensurity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,21 +11,14 @@ jobs:
     steps:
       - name: Clone This Repo
         uses: actions/checkout@v3
-      - name: Build
+      - name: Generate Coverage Report
         run: |
-          cmake -S test/unit-test -B build/ -G "Unix Makefiles"  -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG' 
-          make -C build all
-      - name: Test
-        run: |
-          cd build/
-          ctest -E system --output-on-failure
-          cd ..
-      - name: Run Coverage
-        run: |
-          make -C build/ coverage
+          sudo apt-get install -y lcov sed
+          cmake -S test/unit-test -B build/ -G "Unix Makefiles" -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG'
+          make -C build coverage
       - name: Check Coverage
         uses: FreeRTOS/CI-CD-Github-Actions/coverage-cop@main
         with:
           coverage-file: ./build/coverage.info
-
-  
+          branch-coverage-min: 100
+          line-coverage-min: 100

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI Checks
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+jobs:
+  unittest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone This Repo
+        uses: actions/checkout@v3
+      - name: Build
+        run: |
+          cmake -S test/unit-test -B build/ -G "Unix Makefiles"  -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG' 
+          make -C build all
+      - name: Test
+        run: |
+          cd build/
+          ctest -E system --output-on-failure
+          cd ..
+      - name: Run Coverage
+        run: |
+          make -C build/ coverage
+      - name: Check Coverage
+        uses: FreeRTOS/CI-CD-Github-Actions/coverage-cop@main
+        with:
+          coverage-file: ./build/coverage.info
+
+  


### PR DESCRIPTION
*Issue #, if available:*

### Description of changes:

Added github actions for ensuring code coverage. 

### Test Steps

```
cmake -S test/unit-test -B build/ -G "Unix Makefiles"  -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG'
make -C build all
cd build
ctest -E system --output-on-failure
make coverage
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
