### PR TITLE
Fix UT failure detection in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,21 @@ jobs:
     steps:
       - name: Clone This Repo
         uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Build and Run Tests
+        run: |
+          sudo apt-get install -y lcov sed ruby
+          cmake -S test/unit-test -B build/ -G "Unix Makefiles" -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG'
+          make -C build all
+          cd build && ctest --output-on-failure
       - name: Generate Coverage Report
         run: |
-          sudo apt-get install -y lcov sed
-          cmake -S test/unit-test -B build/ -G "Unix Makefiles" -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG'
           make -C build coverage
       - name: Check Coverage
         uses: FreeRTOS/CI-CD-Github-Actions/coverage-cop@main
         with:
           coverage-file: ./build/coverage.info
           branch-coverage-min: 100
+          functions-coverage-min: 100
           line-coverage-min: 100


### PR DESCRIPTION
Issue #, if available:
NA

Description of changes:

- Added recursive submodule checkout to ensure CMock is available for testing
- Restructured CI workflow to separate build/test execution from coverage generation
- Added explicit make -C build all and ctest --output-on-failure commands for better error handling
- Add coverage requirements for functions with - functions-coverage-min: 100


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
