### PR TITLE
Add check for input length validation for SDP

### DIFF
--- a/source/sdp_deserializer.c
+++ b/source/sdp_deserializer.c
@@ -319,18 +319,19 @@ SdpResult_t SdpDeserializer_ParseBandwidthInfo( const char * pValue,
         {
             if( pValue[ i ] == ':' )
             {
+                numColon += 1;
+
                 if( i == 0 )
                 {
                     result = SDP_RESULT_MESSAGE_MALFORMED_INVALID_BANDWIDTH;
-                    break;
                 }
+                else
+                {
 
-                numColon += 1;
+                    pBandwidthInfo->pBwType = &( pValue[ 0 ] );
+                    pBandwidthInfo->bwTypeLength = i;
 
-                pBandwidthInfo->pBwType = &( pValue[ 0 ] );
-                pBandwidthInfo->bwTypeLength = i;
-
-                if( ( i + 1 ) < valueLength )
+                    if( ( i + 1 ) < valueLength )
                 {
                     sscanfRetVal = sscanf( &( pValue[ i + 1 ] ),
                                            "%" SDP_PRINT_FMT_UINT64,
@@ -344,6 +345,7 @@ SdpResult_t SdpDeserializer_ParseBandwidthInfo( const char * pValue,
                 else
                 {
                     result = SDP_RESULT_MESSAGE_MALFORMED;
+                }
                 }
 
                 break;

--- a/source/sdp_deserializer.c
+++ b/source/sdp_deserializer.c
@@ -319,7 +319,14 @@ SdpResult_t SdpDeserializer_ParseBandwidthInfo( const char * pValue,
         {
             if( pValue[ i ] == ':' )
             {
+                if( i == 0 )
+                {
+                    result = SDP_RESULT_MESSAGE_MALFORMED_INVALID_BANDWIDTH;
+                    break;
+                }
+
                 numColon += 1;
+
                 pBandwidthInfo->pBwType = &( pValue[ 0 ] );
                 pBandwidthInfo->bwTypeLength = i;
 
@@ -427,7 +434,8 @@ SdpResult_t SdpDeserializer_ParseAttribute( const char * pValue,
 
     /* Input check. */
     if( ( pValue == NULL ) ||
-        ( pAttribute == NULL ) )
+        ( pAttribute == NULL ) ||
+        ( valueLength == 0 ) )
     {
         result = SDP_RESULT_BAD_PARAM;
     }
@@ -438,6 +446,12 @@ SdpResult_t SdpDeserializer_ParseAttribute( const char * pValue,
         {
             if( pValue[ i ] == ':' )
             {
+                if( i == 0 )
+                {
+                    result = SDP_RESULT_MESSAGE_MALFORMED_NOT_ENOUGH_INFO;
+                    break;
+                }
+
                 pAttribute->pAttributeName = &( pValue[ 0 ] );
                 pAttribute->attributeNameLength = i;
 

--- a/source/sdp_deserializer.c
+++ b/source/sdp_deserializer.c
@@ -323,15 +323,14 @@ SdpResult_t SdpDeserializer_ParseBandwidthInfo( const char * pValue,
 
                 if( i == 0 )
                 {
-                    result = SDP_RESULT_MESSAGE_MALFORMED_INVALID_BANDWIDTH;
+                    result = SDP_RESULT_MESSAGE_MALFORMED_NOT_ENOUGH_INFO;
+                    break;
                 }
-                else
-                {
 
-                    pBandwidthInfo->pBwType = &( pValue[ 0 ] );
-                    pBandwidthInfo->bwTypeLength = i;
+                pBandwidthInfo->pBwType = &( pValue[ 0 ] );
+                pBandwidthInfo->bwTypeLength = i;
 
-                    if( ( i + 1 ) < valueLength )
+                if( ( i + 1 ) < valueLength )
                 {
                     sscanfRetVal = sscanf( &( pValue[ i + 1 ] ),
                                            "%" SDP_PRINT_FMT_UINT64,
@@ -345,7 +344,6 @@ SdpResult_t SdpDeserializer_ParseBandwidthInfo( const char * pValue,
                 else
                 {
                     result = SDP_RESULT_MESSAGE_MALFORMED;
-                }
                 }
 
                 break;

--- a/test/unit-test/sdp_deserializer/sdp_deserializer_utest.c
+++ b/test/unit-test/sdp_deserializer/sdp_deserializer_utest.c
@@ -953,7 +953,7 @@ void test_SdpDeserializer_ParseBandwidthInfo_EmptyBandwidthModifier( void )
     SdpBandwidthInfo_t bandwidth;
 
     result = SdpDeserializer_ParseBandwidthInfo( originatorBuffer, inputLength, &( bandwidth ) );
-    TEST_ASSERT_EQUAL( SDP_RESULT_MESSAGE_MALFORMED_INVALID_BANDWIDTH, result );
+    TEST_ASSERT_EQUAL( SDP_RESULT_MESSAGE_MALFORMED_NOT_ENOUGH_INFO, result );
 }
 
 /*-----------------------------------------------------------*/
@@ -971,7 +971,7 @@ void test_SdpDeserializer_ParseBandwidthInfo_ColonAtPositionZero( void )
     memset( &( bandwidth ), 0, sizeof( SdpBandwidthInfo_t ) );
 
     result = SdpDeserializer_ParseBandwidthInfo( originatorBuffer, inputLength, &( bandwidth ) );
-    TEST_ASSERT_EQUAL( SDP_RESULT_MESSAGE_MALFORMED_INVALID_BANDWIDTH, result );
+    TEST_ASSERT_EQUAL( SDP_RESULT_MESSAGE_MALFORMED_NOT_ENOUGH_INFO, result );
 }
 
 /*-----------------------------------------------------------*/

--- a/test/unit-test/sdp_deserializer/sdp_deserializer_utest.c
+++ b/test/unit-test/sdp_deserializer/sdp_deserializer_utest.c
@@ -937,7 +937,7 @@ void test_SdpDeserializer_ParseBandwidthInfo_ColonAtEnd( void )
     SdpBandwidthInfo_t bandwidth;
 
     result = SdpDeserializer_ParseBandwidthInfo( originatorBuffer, inputLength, &( bandwidth ) );
-    TEST_ASSERT_EQUAL( SDP_RESULT_MESSAGE_MALFORMED_INVALID_BANDWIDTH, result );
+    TEST_ASSERT_EQUAL( SDP_RESULT_MESSAGE_MALFORMED, result );
 }
 
 /*-----------------------------------------------------------*/

--- a/test/unit-test/sdp_deserializer/sdp_deserializer_utest.c
+++ b/test/unit-test/sdp_deserializer/sdp_deserializer_utest.c
@@ -937,7 +937,41 @@ void test_SdpDeserializer_ParseBandwidthInfo_ColonAtEnd( void )
     SdpBandwidthInfo_t bandwidth;
 
     result = SdpDeserializer_ParseBandwidthInfo( originatorBuffer, inputLength, &( bandwidth ) );
-    TEST_ASSERT_EQUAL( SDP_RESULT_MESSAGE_MALFORMED, result );
+    TEST_ASSERT_EQUAL( SDP_RESULT_MESSAGE_MALFORMED_INVALID_BANDWIDTH, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief The message is malformed with empty bandwidth modifier.
+ */
+void test_SdpDeserializer_ParseBandwidthInfo_EmptyBandwidthModifier( void )
+{
+    SdpResult_t result;
+    char originatorBuffer[] =":128";
+    size_t inputLength = strlen( originatorBuffer );
+    SdpBandwidthInfo_t bandwidth;
+
+    result = SdpDeserializer_ParseBandwidthInfo( originatorBuffer, inputLength, &( bandwidth ) );
+    TEST_ASSERT_EQUAL( SDP_RESULT_MESSAGE_MALFORMED_INVALID_BANDWIDTH, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief The message is malformed with colon at position zero.
+ */
+void test_SdpDeserializer_ParseBandwidthInfo_ColonAtPositionZero( void )
+{
+    SdpResult_t result;
+    char originatorBuffer[] =":256";
+    size_t inputLength = strlen( originatorBuffer );
+    SdpBandwidthInfo_t bandwidth;
+
+    memset( &( bandwidth ), 0, sizeof( SdpBandwidthInfo_t ) );
+
+    result = SdpDeserializer_ParseBandwidthInfo( originatorBuffer, inputLength, &( bandwidth ) );
+    TEST_ASSERT_EQUAL( SDP_RESULT_MESSAGE_MALFORMED_INVALID_BANDWIDTH, result );
 }
 
 /*-----------------------------------------------------------*/
@@ -1089,6 +1123,43 @@ void test_SdpDeserializer_ParseAttribute_BadParams( void )
     result = SdpDeserializer_ParseAttribute( attributeString, attributeStringLength, NULL );
 
     TEST_ASSERT_EQUAL( SDP_RESULT_BAD_PARAM, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief The message is malformed with zero valueLength.
+ */
+void test_SdpDeserializer_ParseAttribute_ZeroValueLength( void )
+{
+    SdpResult_t result;
+    char attributeString[] = "rtpmap";
+    SdpAttribute_t attribute;
+
+    memset( &( attribute ), 0, sizeof( SdpAttribute_t ) );
+
+    result = SdpDeserializer_ParseAttribute( attributeString, 0, &( attribute ) );
+
+    TEST_ASSERT_EQUAL( SDP_RESULT_BAD_PARAM, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief The message is malformed with empty attribute name.
+ */
+void test_SdpDeserializer_ParseAttribute_EmptyAttributeName( void )
+{
+    SdpResult_t result;
+    char attributeString[] = ":value";
+    size_t attributeStringLength = strlen( attributeString );
+    SdpAttribute_t attribute;
+
+    memset( &( attribute ), 0, sizeof( SdpAttribute_t ) );
+
+    result = SdpDeserializer_ParseAttribute( attributeString, attributeStringLength, &( attribute ) );
+
+    TEST_ASSERT_EQUAL( SDP_RESULT_MESSAGE_MALFORMED_NOT_ENOUGH_INFO, result );
 }
 
 /*-----------------------------------------------------------*/

--- a/test/unit-test/sdp_deserializer/sdp_deserializer_utest.c
+++ b/test/unit-test/sdp_deserializer/sdp_deserializer_utest.c
@@ -943,22 +943,6 @@ void test_SdpDeserializer_ParseBandwidthInfo_ColonAtEnd( void )
 /*-----------------------------------------------------------*/
 
 /**
- * @brief The message is malformed with empty bandwidth modifier.
- */
-void test_SdpDeserializer_ParseBandwidthInfo_EmptyBandwidthModifier( void )
-{
-    SdpResult_t result;
-    char originatorBuffer[] =":128";
-    size_t inputLength = strlen( originatorBuffer );
-    SdpBandwidthInfo_t bandwidth;
-
-    result = SdpDeserializer_ParseBandwidthInfo( originatorBuffer, inputLength, &( bandwidth ) );
-    TEST_ASSERT_EQUAL( SDP_RESULT_MESSAGE_MALFORMED_NOT_ENOUGH_INFO, result );
-}
-
-/*-----------------------------------------------------------*/
-
-/**
  * @brief The message is malformed with colon at position zero.
  */
 void test_SdpDeserializer_ParseBandwidthInfo_ColonAtPositionZero( void )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add validation for empty bandwidth modifier and attribute name in SDP deserializer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
